### PR TITLE
RedHat, Fedora, CentOS, and Debian support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ language: ruby
 
 script: bundle exec rake $DO
 env:
-  - BEAKER_PUPPET_COLLECTION=puppet6
+  global:
+    - BEAKER_PUPPET_COLLECTION=puppet6
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache: bundler
 language: ruby
 
 script: bundle exec rake $DO
+env:
+  - BEAKER_PUPPET_COLLECTION=puppet6
 
 jobs:
   include:
@@ -35,31 +37,18 @@ jobs:
       env:
         - DO=beaker
         - BEAKER_set=ubuntu_1404
-        - BEAKER_PUPPET_COLLECTION=puppet5
     - env:
         - DO=beaker
         - BEAKER_set=ubuntu_1604
-        - BEAKER_PUPPET_COLLECTION=puppet5
-    - env:
-        - DO=beaker
-        - BEAKER_set=ubuntu_1604
-        - BEAKER_PUPPET_COLLECTION=puppet6
     - env:
         - DO=beaker
         - BEAKER_set=ubuntu_1804
-        - BEAKER_PUPPET_COLLECTION=puppet5
-    - env:
-        - DO=beaker
-        - BEAKER_set=ubuntu_1804
-        - BEAKER_PUPPET_COLLECTION=puppet6
     - env:
         - DO=beaker
         - BEAKER_set=debian_8
-        - BEAKER_PUPPET_COLLECTION=puppet6
     - env:
         - DO=beaker
         - BEAKER_set=centos_7
-        - BEAKER_PUPPET_COLLECTION=puppet6
     - stage: deploy
       script: true
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,14 @@ jobs:
         - DO=beaker
         - BEAKER_set=ubuntu_1804
         - BEAKER_PUPPET_COLLECTION=puppet6
+    - env:
+        - DO=beaker
+        - BEAKER_set=debian_8
+        - BEAKER_PUPPET_COLLECTION=puppet6
+    - env:
+        - DO=beaker
+        - BEAKER_set=centos_7
+        - BEAKER_PUPPET_COLLECTION=puppet6
     - stage: deploy
       script: true
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,9 @@ jobs:
     - env:
         - DO=beaker
         - BEAKER_set=centos_7
+    - env:
+        - DO=beaker
+        - BEAKER_set=fedora_30
     - stage: deploy
       script: true
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- [GH-11](https://github.com/pegasd/puppet-incron/issues/11): Add `Debian`, `RedHat`, and `CentOS` support:
+- [GH-11](https://github.com/pegasd/puppet-incron/issues/11): Add `Debian`, `RedHat`, `Fedora`, and `CentOS` support:
     - Add data in modules so that incron service name is different under various distributions
-    - Add acceptance testing for `Debian 8` and `CentOS 7`
+    - Add acceptance testing for `Debian 8`, `CentOS 7`, and `Fedora 30`
 
 ### Changed
 - Lower requirement for Puppet version is now bumped up to `4.10.0` as this is the lowest working version for Hiera 5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [GH-11](https://github.com/pegasd/puppet-incron/issues/11): Add `RedHat` and `CentOS` support.
 
 ## [0.6.0] - 2019-08-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Lower requirement for Puppet version is now bumped up to `4.10.0` as this is the lowest working version for Hiera 5.
 - Change testing matrix to only do acceptance testing on latest Puppet versions.
+- Stop managing `group` parameter for `/var/spool/incron` directory and all files that reside there.
 
 ## [0.6.0] - 2019-08-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- [GH-11](https://github.com/pegasd/puppet-incron/issues/11): Add `RedHat` and `CentOS` support.
+- [GH-11](https://github.com/pegasd/puppet-incron/issues/11): Add `Debian`, `RedHat`, and `CentOS` support:
+    - Add data in modules so that incron service name is different under various distributions
+    - Add acceptance testing for `Debian 8` and `CentOS 7`
+
+### Changed
+- Lower requirement for Puppet version is now bumped up to `4.10.0` as this is the lowest working version for Hiera 5.
+- Change testing matrix to only do acceptance testing on latest Puppet versions.
 
 ## [0.6.0] - 2019-08-08
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@
 source 'https://rubygems.org'
 
 group :ed25519 do
-  gem 'ed25519'
   gem 'bcrypt_pbkdf', '< 2.0'
+  gem 'ed25519'
   gem 'rbnacl', '< 5.0'
   gem 'rbnacl-libsodium'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 
 group :ed25519 do
+  gem 'ed25519'
   gem 'bcrypt_pbkdf', '< 2.0'
   gem 'rbnacl', '< 5.0'
   gem 'rbnacl-libsodium'

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -86,6 +86,14 @@ Note: When this is not empty, all users except ones specified here will be able 
 
 Default value: [ ]
 
+##### `service_name`
+
+Data type: `String[1]`
+
+Incron service's name.
+
+Default value: 'incrond'
+
 ##### `service_manage`
 
 Data type: `Boolean`

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,0 +1,3 @@
+---
+incron::service_name: incron
+...

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -1,0 +1,3 @@
+---
+incron::service_name: incrond
+...

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,13 @@
+---
+version: 5
+
+defaults:
+  datadir: data
+  data_hash: yaml_data
+
+hierarchy:
+  - name: Operating System Family
+    path: '%{facts.os.family}.yaml'
+  - name: Common Configuration
+    path: common.yaml
+...

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,9 @@
 #   List of users specifically denied to use `incrontab(1)`.
 #   Note: When this is not empty, all users except ones specified here will be able to use `incrontab`.
 #
+# @param service_name
+#   Incron service's name.
+#
 # @param service_manage
 #   Whether to manage incron service at all.
 #
@@ -44,6 +47,7 @@ class incron (
   Array[String[1]]       $denied_users    = [ ],
 
   # incron::service
+  String[1]              $service_name    = 'incrond',
   Boolean                $service_manage  = true,
   Enum[running, stopped] $service_ensure  = running,
   Boolean                $service_enable  = true,

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -33,7 +33,6 @@ define incron::job (
       ensure => present,
       mode   => '0600',
       owner  => $user,
-      group  => 'incron',
     }
   }
 

--- a/manifests/purge.pp
+++ b/manifests/purge.pp
@@ -17,7 +17,6 @@ class incron::purge {
   file { '/var/spool/incron':
     ensure  => directory,
     owner   => 'root',
-    group   => 'incron',
     mode    => '1731',
     recurse => true,
     purge   => true,

--- a/manifests/remove.pp
+++ b/manifests/remove.pp
@@ -3,7 +3,7 @@
 # @api private
 class incron::remove {
 
-  if versioncmp($facts['os']['release']['full'], '15.04') >= 0 {
+  if $facts['service_provider'] == 'systemd' {
     service { 'incron':
       ensure   => stopped,
       provider => systemd,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,6 +6,7 @@ class incron::service {
   if $::incron::service_manage {
     service { 'incron':
       ensure     => $::incron::service_ensure,
+      name       => $::incron::service_name,
       enable     => $::incron::service_enable,
       hasrestart => true,
       hasstatus  => true,

--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.4.0 < 7.0.0"
+      "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
   "pdk-version": "1.13.0",

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,14 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",

--- a/metadata.json
+++ b/metadata.json
@@ -34,6 +34,12 @@
       ]
     },
     {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "30"
+      ]
+    },
+    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "5",

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "RedHat",
+      "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "5",
         "6",
@@ -27,7 +27,14 @@
       ]
     },
     {
-      "operatingsystem": "CentOS",
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "5",
         "6",

--- a/metadata.json
+++ b/metadata.json
@@ -27,6 +27,14 @@
       ]
     },
     {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",
@@ -41,7 +49,7 @@
       "version_requirement": ">= 4.4.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.12.0",
+  "pdk-version": "1.13.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "1.12.0-0-g55d9ae2"
+  "template-ref": "1.13.0-0-g66e1443"
 }

--- a/spec/acceptance/install_remove_spec.rb
+++ b/spec/acceptance/install_remove_spec.rb
@@ -2,6 +2,13 @@
 
 require 'spec_helper_acceptance'
 
+case os[:family]
+when 'redhat', 'fedora'
+  servicename = 'incrond'
+else
+  servicename = 'incron'
+end
+
 describe 'incron' do
   context 'installs?' do
     pp = <<~PUPPET
@@ -16,7 +23,7 @@ describe 'incron' do
     describe package('incron') do
       it { is_expected.to be_installed }
     end
-    describe service('incron') do
+    describe service(servicename) do
       it { is_expected.to be_running }
     end
     describe file('/etc/incron.d') do
@@ -37,7 +44,7 @@ describe 'incron' do
     describe package('incron') do
       it { is_expected.not_to be_installed }
     end
-    describe service('incron') do
+    describe service(servicename) do
       it { is_expected.not_to be_running }
     end
 

--- a/spec/acceptance/nodesets/centos_7.yml
+++ b/spec/acceptance/nodesets/centos_7.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  centos-7-x64:
+    platform: el-7-x86_64
+    hypervisor: docker
+    image: centos:7
+    docker_preserve_image: true
+    docker_cmd: '["/usr/sbin/init"]'
+    # install various tools required to get the image up to usable levels
+    docker_image_commands:
+      - 'yum install -y crontabs tar wget openssl sysvinit-tools iproute which initscripts'
+CONFIG:
+  trace_limit: 200

--- a/spec/acceptance/nodesets/centos_7.yml
+++ b/spec/acceptance/nodesets/centos_7.yml
@@ -9,4 +9,4 @@ HOSTS:
     docker_image_commands:
       - 'yum install -y crontabs tar wget openssl sysvinit-tools iproute which initscripts'
 CONFIG:
-  trace_limit: 200
+  type: foss

--- a/spec/acceptance/nodesets/centos_7.yml
+++ b/spec/acceptance/nodesets/centos_7.yml
@@ -5,7 +5,6 @@ HOSTS:
     image: centos:7
     docker_preserve_image: true
     docker_cmd: '["/usr/sbin/init"]'
-    # install various tools required to get the image up to usable levels
     docker_image_commands:
       - 'yum install -y wget epel-release'
 CONFIG:

--- a/spec/acceptance/nodesets/centos_7.yml
+++ b/spec/acceptance/nodesets/centos_7.yml
@@ -7,6 +7,6 @@ HOSTS:
     docker_cmd: '["/usr/sbin/init"]'
     # install various tools required to get the image up to usable levels
     docker_image_commands:
-      - 'yum install -y crontabs tar wget openssl sysvinit-tools iproute which initscripts'
+      - 'yum install -y wget epel-release'
 CONFIG:
   type: foss

--- a/spec/acceptance/nodesets/debian_8.yml
+++ b/spec/acceptance/nodesets/debian_8.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  debian-8-x64:
+    platform: debian-8-amd64
+    hypervisor: docker
+    image: debian:8
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'apt-get update && apt-get install -y net-tools wget locales strace lsof && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen'
+CONFIG:
+  trace_limit: 200

--- a/spec/acceptance/nodesets/debian_8.yml
+++ b/spec/acceptance/nodesets/debian_8.yml
@@ -6,6 +6,6 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'apt-get update && apt-get install -y net-tools wget locales strace lsof && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen'
+      - 'apt-get update && apt-get install -y wget locales sudo && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen'
 CONFIG:
   type: foss

--- a/spec/acceptance/nodesets/debian_8.yml
+++ b/spec/acceptance/nodesets/debian_8.yml
@@ -8,4 +8,4 @@ HOSTS:
     docker_image_commands:
       - 'apt-get update && apt-get install -y net-tools wget locales strace lsof && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen'
 CONFIG:
-  trace_limit: 200
+  type: foss

--- a/spec/acceptance/nodesets/fedora_30.yml
+++ b/spec/acceptance/nodesets/fedora_30.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  fedora-30-x64:
+    platform: fedora-30-x86_64
+    hypervisor: docker
+    image: fedora:30
+    docker_preserve_image: true
+    docker_cmd: '["/usr/sbin/init"]'
+    docker_image_commands:
+      - 'yum install -y wget glibc-locale-source'
+      - 'localedef -v -c -i en_US -f UTF-8 en_US.UTF-8 || true'
+CONFIG:
+  type: foss

--- a/spec/classes/incron_spec.rb
+++ b/spec/classes/incron_spec.rb
@@ -54,15 +54,26 @@ describe 'incron' do
     end
 
     describe 'incron::service' do
-      it { is_expected.to compile.with_all_deps }
-      it {
-        is_expected.to contain_service('incron').only_with(
-          ensure:     :running,
-          enable:     true,
-          hasrestart: true,
-          hasstatus:  true,
-        )
-      }
+      on_supported_os.each do |os_name, facts|
+        context "on #{os_name}" do
+          let(:facts) { facts }
+
+          it { is_expected.to compile.with_all_deps }
+
+          facts[:os]['family'] == 'RedHat' ? service_name = 'incrond' : service_name = 'incron'
+
+          it {
+            is_expected.to contain_service('incron')
+              .only_with(
+                name:       service_name,
+                ensure:     :running,
+                enable:     true,
+                hasrestart: true,
+                hasstatus:  true,
+              )
+          }
+        end
+      end
     end
 
     describe 'incron::purge' do

--- a/spec/classes/incron_spec.rb
+++ b/spec/classes/incron_spec.rb
@@ -96,7 +96,6 @@ describe 'incron' do
           purge:   true,
           force:   true,
           owner:   'root',
-          group:   'incron',
           mode:    '1731',
         )
       }

--- a/spec/classes/incron_spec.rb
+++ b/spec/classes/incron_spec.rb
@@ -163,7 +163,6 @@ describe 'incron' do
   end
 
   context 'with ensure => absent' do
-    let(:facts) { { os: { release: { full: '14.04' } } } }
     let(:params) { { ensure: 'absent' } }
 
     it { is_expected.to compile.with_all_deps }
@@ -189,17 +188,7 @@ describe 'incron' do
         it { is_expected.to contain_file(removed_file).only_with(ensure: :absent, force: true) }
       end
 
-      on_supported_os.each do |os_ver, facts|
-        context "on Ubuntu #{os_ver}" do
-          let(:facts) { facts }
-
-          if facts[:os]['release']['full'] == '14.04'
-            it { is_expected.not_to contain_service('incron') }
-          else
-            it { is_expected.to contain_service('incron').with_ensure(:stopped).with_provider(:systemd) }
-          end
-        end
-      end
+      it { is_expected.to contain_service('incron').with_ensure(:stopped).with_provider(:systemd) }
     end
   end
 end

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -1,2 +1,4 @@
 ---
-osfamily: Debian
+osfamily: Debian # Fix for running specs under macOS
+service_provider: systemd
+...

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -25,7 +25,6 @@ describe 'incron::job' do
           ensure: :present,
           mode:   '0600',
           owner:  'root',
-          group:  'incron',
         )
     }
 


### PR DESCRIPTION
This PR:
* makes service name for `incron` configurable through data in modules
* sets correct service name for RedHat-based distributions
* checks for `$facts['service_provider']` inside `incron::remove` instead of relying upon OS version